### PR TITLE
Fix for Dockerfile smell DL3015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ due to content-only changes (this is one of the reasons a version may be listed
 here as having "no notable changes"); currently, no version increment is
 performed in such case.
 
+## [Unreleased]
+### Changed
+- Docker images now pack less dependencies, thanks to @grosa1.
+
 ## [4.3.0] - 2023-02-26
 ### Changed
 - Update to LiteDB v5.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM mcr.microsoft.com/powershell:7.1.3-debian-10 AS talks-env
 
 # First, install curl to be able to install Node.js, and then install Node.js itself:
 RUN apt-get update \
-    && apt-get install -y curl \
+    && apt-get install --no-install-recommends -y curl \
     && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y \
+    && apt-get install --no-install-recommends -y \
         nodejs \
     && rm -rf /var/lib/apt/lists/*
 
@@ -20,7 +20,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 # Install Node.js:
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y \
+    && apt-get install --no-install-recommends -y \
         nodejs \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance